### PR TITLE
Updated plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,14 +98,15 @@
                                     As we are downloading reveal.js in runtime, it sits in a nonstandard folder `reveal.js-${revealjs.version}`
                                 -->
                                 <revealjsdir>reveal.js-${revealjs.version}</revealjsdir>
+	                            <src-incl>${project.basedir}/</src-incl>
                                 <!-- put here the reveal.js specific attributes -->
-                                <sourcedir>${basedir}/src/main/java</sourcedir>
-	                            <revealjs_customtheme>${theme.dir}/schauderhaft.css</revealjs_customtheme>
+	                            <revealjs_customtheme>theme/schauderhaft.css</revealjs_customtheme>
 	                            <revealjs_transition>linear</revealjs_transition>
                                 <project-version>${project.version}</project-version>
 	                            <revealjs_history>true</revealjs_history>
 	                            <revealjs_width>1280</revealjs_width>
 	                            <revealjs_height>720</revealjs_height>
+	                            <revealjs_margin>0</revealjs_margin>
                             </attributes>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -12,14 +12,11 @@
     <properties>
         <project.slides.directory>${project.build.directory}/generated-slides</project.slides.directory>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.6</asciidoctor.maven.plugin.version>
-	    <!-- switching to 1.5.6 breaks background images -->
-        <asciidoctorj.version>1.5.5</asciidoctorj.version>
-        <jruby.version>1.7.26</jruby.version>
-        <revealjs.version>3.6.0</revealjs.version>
-        <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->
-	    <!-- switching to 1.1.x breaks conversion -->
-        <asciidoctor-revealjs.version>1.0.4</asciidoctor-revealjs.version>
+        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>1.5.7</asciidoctorj.version>
+        <jruby.version>9.1.17.0</jruby.version>
+        <revealjs.version>3.7.0</revealjs.version>
+        <asciidoctor-revealjs.version>1.1.3</asciidoctor-revealjs.version>
         <theme.dir>${project.slides.directory}/theme</theme.dir>
     </properties>
 
@@ -29,7 +26,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.3.0</version>
+                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>install-asciidoctor-revealjs</id>
@@ -93,7 +90,7 @@
                             <outputDirectory>${project.slides.directory}</outputDirectory>
                             <backend>revealjs</backend>
                             <templateDir>
-                                ${project.build.directory}/asciidoctor-reveal.js-${asciidoctor-revealjs.version}/templates/slim
+                                ${project.build.directory}/asciidoctor-reveal.js-${asciidoctor-revealjs.version}/templates
                             </templateDir>
                             <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
@@ -117,7 +114,7 @@
             <plugin>
                 <groupId>nl.geodienstencentrum.maven</groupId>
                 <artifactId>sass-maven-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>update-template-stylesheets</id>
@@ -133,7 +130,7 @@
             </plugin>
 	        <plugin>
 		        <artifactId>maven-resources-plugin</artifactId>
-		        <version>3.0.2</version>
+		        <version>3.1.0</version>
 		        <executions>
 			        <execution>
 				        <id>copy-stylesheet-resources</id>

--- a/src/main/asciidoc/footer.ad
+++ b/src/main/asciidoc/footer.ad
@@ -2,6 +2,17 @@
 ++++
 <script type="text/javascript">
     window.addEventListener("load", function() {
+    	Reveal.configure({
+          keyboard: {
+             39: 'next', // Right Arrow
+             37: 'prev'  // Left Arrow
+          }
+        });
+    } );
+</script>
+
+<script type="text/javascript">
+    window.addEventListener("load", function() {
 
         revealDiv = document.querySelector("body div.reveal")
         footer = document.getElementById("schauderhaft-footer");

--- a/src/main/asciidoc/self.ad
+++ b/src/main/asciidoc/self.ad
@@ -1,6 +1,6 @@
 == Jens Schauder
 
-Vater, Spieler, Läufer, Boulderer
+Dad, Board&Roleplaying Gamer, Runner, Freeletics Masochist
 
 ++++
 <span>
@@ -16,4 +16,3 @@ JUG Organizer
     +++
 
 link:{slide-link}[Folien online: {slide-link}]
-

--- a/src/main/asciidoc/self.ad
+++ b/src/main/asciidoc/self.ad
@@ -1,6 +1,6 @@
 == Jens Schauder
 
-Dad, Board&Roleplaying Gamer, Runner, Freeletics Masochist
+Dad, Board&Roleplaying Gamer, Runner, Bouldering, Freeletics Masochist
 
 ++++
 <span>
@@ -15,4 +15,4 @@ JUG Organizer
     <img src="images/jug_final_small.png" style="vertical-align: middle; border:none;" width="150"/>
     +++
 
-link:{slide-link}[Folien online: {slide-link}]
+link:{slide-link}[Slides online: {slide-link}]

--- a/src/main/sass/schauderhaft.scss
+++ b/src/main/sass/schauderhaft.scss
@@ -127,8 +127,9 @@ $selectionColor: $color-primary-0;
   vertical-align: baseline;
 }
 
-.reveal pre {
-  width: 100%
+.reveal section>div:first-child pre code {
+  height: 100%;
+  max-height: 600px;
 }
 
 .reveal pre code {
@@ -141,6 +142,11 @@ $selectionColor: $color-primary-0;
 body {
   // pattern from https://subtlepatterns.com/skin-side-up/
   background-image: url('images/skin_side_up.png');
+}
+
+// shadow for background images
+div.slide-background.present:not(.stack) {
+  filter: drop-shadow(5px 5px 5px $color-primary-1);
 }
 
 .reveal .attribution {

--- a/src/main/sass/schauderhaft.scss
+++ b/src/main/sass/schauderhaft.scss
@@ -5,8 +5,8 @@
  * background pattern from https://subtlepatterns.com/skin-side-up/*
  */
 // Default mixins and settings -----------------
-@import "../../../target/generated-slides/reveal.js-3.6.0/css/theme/template/mixins.scss";
-@import "../../../target/generated-slides/reveal.js-3.6.0/css/theme/template/settings.scss";
+@import "../../../target/generated-slides/reveal.js-3.7.0/css/theme/template/mixins.scss";
+@import "../../../target/generated-slides/reveal.js-3.7.0/css/theme/template/settings.scss";
 // ---------------------------------------------
 // Include theme-specific fonts
 //@import url('https://fonts.googleapis.com/css?family=Amatic+SC|Roboto:100,300|Roboto+Mono&subset=latin-ext');
@@ -96,7 +96,7 @@ $selectionBackgroundColor: $color-secondary-1;
 $selectionColor: $color-primary-0;
 
 // Theme template ------------------------------
-@import "../../../target/generated-slides/reveal.js-3.6.0/css/theme/template/theme";
+@import "../../../target/generated-slides/reveal.js-3.7.0/css/theme/template/theme";
 // ---------------------------------------------
 
 // some overrides after theme template import
@@ -211,4 +211,16 @@ section[data-background-size] .footer span {
   text-align: left;
   margin-bottom: 10px;
   font-size: 60%;
+}
+
+/*Fix background images*/
+.reveal section img {
+  background: none;
+  border: none;
+  box-shadow: none;
+}
+
+/*Fix box code*/
+.reveal pre {
+  box-shadow: none;
 }


### PR DESCRIPTION
Updated plugin versions.
Note: download-maven-plugin v1.4.1 breaks cache. We need to delete the previous .m2/repository/.cache/download-maven-plugin folder.